### PR TITLE
Add Dockerfile and GitHub workflow to push Docker image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.gradle
+build
+*.iml
+*.log
+.idea
+.vscode
+.DS_Store

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build and Push Docker image to GHCR
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Step 2: Log in to GitHub Container Registry (GHCR)
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Step 3: Build the Docker image
+      - name: Build Docker image
+        run: |
+          IMAGE_NAME=ghcr.io/${{ github.repository_owner }}/dencode-web:latest
+          docker build -t $IMAGE_NAME .
+
+      # Step 4: Push the Docker image to GitHub Container Registry
+      - name: Push Docker image to GHCR
+        run: |
+          IMAGE_NAME=ghcr.io/${{ github.repository_owner }}/dencode-web:latest
+          docker push $IMAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use OpenJDK 21 as the base image
+FROM openjdk:21-jdk-slim
+
+# Installing required dependencies
+RUN apt-get update && apt-get install -yq \
+    findutils \
+    python3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment variables!
+ENV APP_HOME=/app
+
+# Create application directory
+WORKDIR $APP_HOME
+
+# Copy the project files to the container
+COPY . .
+
+# Grant execute permission for gradlew
+RUN chmod +x ./gradlew
+
+# Set GRADLE_USER_HOME to avoid permission issues
+ENV GRADLE_USER_HOME=$APP_HOME/gradle-cache
+
+# Run the Gradle build to fetch dependencies and build the project
+RUN ./gradlew clean build --no-daemon
+
+# Expose the default port the app runs on
+EXPOSE 8080
+
+# Command to run the application
+CMD ["./gradlew", "appRunStage", "--no-daemon"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Open a shell or command line and execute the following commands on the project r
 
 After startup, DenCode can be accessed at http://localhost:8080/ .
 
+### Run using docker:
+```bash
+docker run -p 8080:8080 ghcr.io/mozq/dencode-web:latest
+```
+
 ### Deploy to Google App Engine:
 
 Install [Google Cloud SDK](https://cloud.google.com/sdk/) and execute the following commands. `gcloud` commands only needs to be executed for the first time.


### PR DESCRIPTION
First of all, thank you for this useful repository.

I’ve added a Dockerfile and a GitHub Actions workflow to push the Docker image to GHCR.

Changes include:
- Added a `.dockerignore` file
- Added a Dockerfile to build the project
- Added a GitHub Actions workflow to build and push the Docker image to GHCR
- Updated the README with Docker usage and Google App Engine deployment instructions

Feel free to make any changes!